### PR TITLE
Docker placeholder

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -43,7 +43,7 @@ variables:
   image: dockerhub.ebi.ac.uk/ensembl-web/deploy-tools:0.3
 
   script:
-    - kustomize edit set image ${DOCKER_IMAGE}
+    - kustomize edit set image DOCKER_IMAGE=${DOCKER_IMAGE}
     - kustomize build . | kubectl apply -f -
 
 # Template to deploy to dev (Review apps)
@@ -56,7 +56,7 @@ variables:
 
   script:
     - kustomize edit set namesuffix -- -${CI_COMMIT_REF_SLUG}
-    - kustomize edit set image ${DOCKER_IMAGE}
+    - kustomize edit set image DOCKER_IMAGE=${DOCKER_IMAGE}
     - kustomize edit add label -f environment:${CI_COMMIT_REF_SLUG}
     - kustomize build . | kubectl apply -f -
 

--- a/k8s/base/deployment.yaml
+++ b/k8s/base/deployment.yaml
@@ -13,7 +13,7 @@ spec:
         - name: ensemblweb-pull-secret
       containers:
       - name: ensembl-help-and-docs
-        image: dockerhub.ebi.ac.uk/ensembl-web/ensembl-help-and-docs:TAG
+        image: DOCKER_IMAGE
         command: [ "npm", "run", "start-server" ]
         ports:
           - containerPort: 3000


### PR DESCRIPTION
Docker image place holder for deployment. In the deployment job, this will replace both docker image name and tag. This makes it independent of a particular docker registry provided appropriate image pull secrets are in place. 