### PR TITLE
Update GraphQL core URL

### DIFF
--- a/docs/ensembl-help/using-ensembl/getting-ensembl-data/tools-and-apis/graphql/getting-started.md
+++ b/docs/ensembl-help/using-ensembl/getting-ensembl-data/tools-and-apis/graphql/getting-started.md
@@ -7,10 +7,10 @@ related_articles:
 ---
 # Accessing Ensembl GraphQL services
 
-The Ensembl GraphQL services can be accessed here:[https://beta.ensembl.org/data/graphql](https://beta.ensembl.org/data/graphql).
+The Ensembl GraphQL services can be accessed here:[https://beta.ensembl.org/data/graphql/core](https://beta.ensembl.org/data/graphql/core).
 
 ## Schemas and documentation
-If you wish to interrogate the service and explore the documentation, [a GraphQL playground](/data/graphql) can be accessed via your browser.
+If you wish to interrogate the service and explore the documentation, [a GraphQL playground](/data/graphql/core) can be accessed via your browser.
 
 ## Genomes
 
@@ -224,7 +224,7 @@ This example Python script shows how data can be accessed using GraphQL.
 import requests
 import json
 
-base_url = 'https://beta.ensembl.org/data/graphql'
+base_url = 'https://beta.ensembl.org/data/graphql/core'
 
 genome_id_graphql_query = '''query{
   genomes(

--- a/docs/ensembl-help/using-ensembl/getting-ensembl-data/tools-and-apis/refget/refget-client.ipynb
+++ b/docs/ensembl-help/using-ensembl/getting-ensembl-data/tools-and-apis/refget/refget-client.ipynb
@@ -36,12 +36,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
     "# Default endpoints\n",
-    "ensembl_graphql = \"https://beta.ensembl.org/data/graphql\"\n",
+    "ensembl_graphql = \"https://beta.ensembl.org/data/graphql/core\"\n",
     "ensembl_refget = \"https://beta.ensembl.org/data/refget\"\n",
     "\n",
     "# If set to true we will use the requests version\n",


### PR DESCRIPTION
Updated GraphQL core URL to become `data/graphql/core` instead of `data/graphql`

We will eventually have `data/graphql/variation` and `data/graphql/compara` as well