### PR TITLE
Change prokaryotic annotation header

### DIFF
--- a/docs/ensembl-help/ensembl-data/annotation-and-prediction/toc.yml
+++ b/docs/ensembl-help/ensembl-data/annotation-and-prediction/toc.yml
@@ -6,7 +6,7 @@
   href: vertebrate-annotation.md
 - name: Non vertebrate genome annotation
   href: non-vertebrate-annotation.md
-- name: Prokaryotic genome annotation
+- name: Prokka genome annotation
   href: prokka-annotation.md
 - name: BRAKER2 genome annotation
   href: braker2-annotation.md


### PR DESCRIPTION
Very slight change to prokaryotic annotation documentation title, the doc is specific to the use of the Prokka pipeline, specifying this in the name leaves room for alternative pipelines to be documented for Prokaryotes
Should results in url: https://beta.ensembl.org/help/articles/prokka-genome-annotation, note this will need to be updated in metadata for existing bacterial genomes where provider_url has been set to https://beta.ensembl.org/info/genome/prokka-genome-annotation 